### PR TITLE
fix Handler instance reference inside closure

### DIFF
--- a/Connection/Handler.php
+++ b/Connection/Handler.php
@@ -257,14 +257,16 @@ abstract class Handler {
         $old  = $this->getConnection()->_setStream($node->getSocket());
         $send = $this->_send($message, $node);
 
-        if($send instanceof \Closure)
-            return function ( ) use ( &$send, &$old ) {
+        if($send instanceof \Closure) {
+            $self = $this;
+            return function ( ) use ( &$send, &$old, &$self ) {
 
                 $out = call_user_func_array($send, func_get_args());
-                $this->getConnection()->_setStream($old);
+                $self->getConnection()->_setStream($old);
 
                 return $out;
             };
+        }
 
         $this->getConnection()->_setStream($old);
 


### PR DESCRIPTION
When sending messages through [hoa/websocket](https://github.com/hoaproject/Websocket) using PHP 5.3.26, the following error was occurring:

```
Fatal error: Using $this when not in object context in Hoa/Socket/Connection/Handler.php on line 264
```
