### PR TITLE
Socket state connected after construct.

### DIFF
--- a/Connection/Connection.php
+++ b/Connection/Connection.php
@@ -214,11 +214,11 @@ abstract class Connection
      */
     public function connect ( ) {
 
-        $this->_disconnect = false;
         parent::__construct(
             $this->getSocket()->__toString(),
             $this->getContext()
         );
+        $this->_disconnect = false;
 
         return $this;
     }


### PR DESCRIPTION
We should construct connection before guessing it's connected. If an error appears during construction, it'll not set connection status to “connected“

A case with websockets:

``` php
var_dump($this->client->getConnection()->isDisconnected()); // true

try{
  $this->client->connect();
} catch (\Hoa\Socket\Exception $e) {
  // je passe dans le catch parce que j'ai un fail 
  $this->logger->crit(sprintf('Cannot connect to websocket server, error: %s', $e->getMessage()));
}

var_dump($this->client->getConnection()->isDisconnected()); // false
```
