### PR TITLE
Do not call Handler::_run if the selected node is still a resource.

### DIFF
--- a/Connection/Handler.php
+++ b/Connection/Handler.php
@@ -153,27 +153,27 @@ abstract class Handler
         while (true) {
             foreach ($connection->select() as $node) {
 
-            // Connection has failed to detect the node, maybe it is a resource
-            // from a merged client in a server.
-            if (false === is_object($node)) {
-                $socket = $node;
+                // Connection has failed to detect the node, maybe it is a resource
+                // from a merged client in a server.
+                if (false === is_object($node)) {
+                    $socket = $node;
 
-                foreach ($this->_connections as $other) {
-                    $otherConnection = $other->getOriginalConnection();
+                    foreach ($this->_connections as $other) {
+                        $otherConnection = $other->getOriginalConnection();
 
-                    if (!($otherConnection instanceof Socket\Client)) {
-                        continue;
-                    }
+                        if ( ! ($otherConnection instanceof Socket\Client)) {
+                            continue;
+                        }
 
-                    $node = $otherConnection->getCurrentNode();
+                        $node = $otherConnection->getCurrentNode();
 
-                    if ($node->getSocket() === $socket) {
-                        $other->_run($node);
+                        if ($node->getSocket() === $socket) {
+                            $other->_run($node);
 
-                        continue 2;
+                            continue 2;
+                        }
                     }
                 }
-            }
 
                 foreach ($this->_connections as $other) {
                     if (true === $connection->is($other->getOriginalConnection())) {
@@ -181,6 +181,12 @@ abstract class Handler
 
                         continue 2;
                     }
+                }
+
+                // Node may still be a resource if there are no connections
+                // from which to get a node
+                if (false === is_object($node)) {
+                    continue;
                 }
 
                 $this->_run($node);


### PR DESCRIPTION
While running a server and having many clients calling it, it is possible to get in a state where

* if (false === is_object($node)) => true
* foreach ($this->_connections as $other) => $this->_connections is empty

Thus, `$node` is never replaced by a `Node` object. Thus, when `$this->_run($node);` is called, it is given a `resource` but expects a `Node` and thus it crashes.

This fix may not be the most appropriate way to fix this, but it does fix the issue!