### PR TITLE
Server: Fix throws exceptions while broadcasting messages.

### DIFF
--- a/Connection/Connection.php
+++ b/Connection/Connection.php
@@ -810,6 +810,7 @@ abstract class Connection
      * @param   int     $length    Length.
      * @return  mixed
      * @throws  \Hoa\Socket\Exception
+     * @throws  \Hoa\Socket\Exception\BrokenPipe
      */
     public function write($string, $length)
     {
@@ -850,7 +851,7 @@ abstract class Connection
         }
 
         if (-1 === $out) {
-            throw new Socket\Exception('Pipe is broken, cannot write data.', 5);
+            throw new Socket\Exception\BrokenPipe('Pipe is broken, cannot write data.', 5);
         }
 
         return $out;

--- a/Exception/BrokenPipe.php
+++ b/Exception/BrokenPipe.php
@@ -34,18 +34,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Hoa\Socket;
-
-use Hoa\Exception as HoaException;
+namespace Hoa\Socket\Exception;
 
 /**
- * Class \Hoa\Socket\Exception.
+ * Class \Hoa\Socket\Exception\BrokenPipe.
  *
- * Extending the \Hoa\Exception\Exception class.
+ * Extending the \Hoa\Socket\Exception\Exception class.
  *
  * @copyright  Copyright © 2007-2016 Hoa community
  * @license    New BSD License
  */
-class Exception extends HoaException
+class BrokenPipe extends Exception
 {
 }

--- a/Exception/Exception.php
+++ b/Exception/Exception.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2016, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Socket\Exception;
+
+use Hoa\Consistency;
+use Hoa\Exception as HoaException;
+
+/**
+ * Class \Hoa\Socket\Exception\Exception.
+ *
+ * Extending the \Hoa\Exception\Exception class.
+ *
+ * @copyright  Copyright © 2007-2016 Hoa community
+ * @license    New BSD License
+ */
+class Exception extends HoaException
+{
+}
+
+Consistency::flexEntity('Hoa\Socket\Exception\Exception');


### PR DESCRIPTION
While broadcasting a message to some nodes an error can occur because the node connection is closed but isn't yet removed from the *to send* list.
Here we will isolate each sends and then thrown a group of `BrokenPipeException`. This way if the first node is closed each other will still receive the message and then we'll emit an exception.

Fix https://github.com/hoaproject/Socket/pull/32 (`Socket` side)