### PR TITLE
Add TLSv* constants in client and server

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -54,49 +54,77 @@ class Client extends Connection
      *
      * @const int
      */
-    const ASYNCHRONOUS      = STREAM_CLIENT_ASYNC_CONNECT;
+    const ASYNCHRONOUS       = STREAM_CLIENT_ASYNC_CONNECT;
 
     /**
      * Open client socket connection.
      *
      * @const int
      */
-    const CONNECT           = STREAM_CLIENT_CONNECT;
+    const CONNECT            = STREAM_CLIENT_CONNECT;
 
     /**
      * Client socket should remain persistent between page loads.
      *
      * @const int
      */
-    const PERSISTENT        = STREAM_CLIENT_PERSISTENT;
+    const PERSISTENT         = STREAM_CLIENT_PERSISTENT;
 
     /**
      * Encryption: SSLv2.
      *
      * @const int
      */
-    const ENCRYPTION_SSLv2  = STREAM_CRYPTO_METHOD_SSLv2_CLIENT;
+    const ENCRYPTION_SSLv2   = STREAM_CRYPTO_METHOD_SSLv2_CLIENT;
 
     /**
      * Encryption: SSLv3.
      *
      * @const int
      */
-    const ENCRYPTION_SSLv3  = STREAM_CRYPTO_METHOD_SSLv3_CLIENT;
+    const ENCRYPTION_SSLv3   = STREAM_CRYPTO_METHOD_SSLv3_CLIENT;
 
     /**
      * Encryption: SSLv2.3.
      *
      * @const int
      */
-    const ENCRYPTION_SSLv23 = STREAM_CRYPTO_METHOD_SSLv23_CLIENT;
+    const ENCRYPTION_SSLv23  = STREAM_CRYPTO_METHOD_SSLv23_CLIENT;
 
     /**
      * Encryption: TLS.
      *
      * @const int
      */
-    const ENCRYPTION_TLS    = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+    const ENCRYPTION_TLS     = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+
+    /**
+     * Encryption: TLSv1.0.
+     *
+     * @const int
+     */
+    const ENCRYPTION_TLSv1_0 = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+
+    /**
+     * Encryption: TLSv1.1.
+     *
+     * @const int
+     */
+    const ENCRYPTION_TLSv1_1 = STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+
+    /**
+     * Encryption: TLSv1.2.
+     *
+     * @const int
+     */
+    const ENCRYPTION_TLSv1_2 = STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+
+    /**
+     * Encryption: ANY
+     *
+     * @const int
+     */
+    const ENCRYPTION_ANY     = STREAM_CRYPTO_METHOD_ANY_CLIENT;
 
     /**
      * Stack of connections.

--- a/Server.php
+++ b/Server.php
@@ -54,42 +54,70 @@ class Server extends Connection
      *
      * @const int
      */
-    const BIND              = STREAM_SERVER_BIND;
+    const BIND               = STREAM_SERVER_BIND;
 
     /**
      * Tell a stream to start listening on the socket.
      *
      * @const int
      */
-    const LISTEN            = STREAM_SERVER_LISTEN;
+    const LISTEN             = STREAM_SERVER_LISTEN;
 
     /**
      * Encryption: SSLv2.
      *
      * @const int
      */
-    const ENCRYPTION_SSLv2  = STREAM_CRYPTO_METHOD_SSLv2_SERVER;
+    const ENCRYPTION_SSLv2   = STREAM_CRYPTO_METHOD_SSLv2_SERVER;
 
     /**
      * Encryption: SSLv3.
      *
      * @const int
      */
-    const ENCRYPTION_SSLv3  = STREAM_CRYPTO_METHOD_SSLv3_SERVER;
+    const ENCRYPTION_SSLv3   = STREAM_CRYPTO_METHOD_SSLv3_SERVER;
 
     /**
      * Encryption: SSLv2.3.
      *
      * @const int
      */
-    const ENCRYPTION_SSLv23 = STREAM_CRYPTO_METHOD_SSLv23_SERVER;
+    const ENCRYPTION_SSLv23  = STREAM_CRYPTO_METHOD_SSLv23_SERVER;
 
     /**
      * Encryption: TLS.
      *
      * @const int
      */
-    const ENCRYPTION_TLS    = STREAM_CRYPTO_METHOD_TLS_SERVER;
+    const ENCRYPTION_TLS     = STREAM_CRYPTO_METHOD_TLS_SERVER;
+
+    /**
+     * Encryption: TLSv1.0.
+     *
+     * @const int
+     */
+    const ENCRYPTION_TLSv1_0 = STREAM_CRYPTO_METHOD_TLSv1_0_SERVER;
+
+    /**
+     * Encryption: TLSv1.1.
+     *
+     * @const int
+     */
+    const ENCRYPTION_TLSv1_1 = STREAM_CRYPTO_METHOD_TLSv1_1_SERVER;
+
+    /**
+     * Encryption: TLSv1.2.
+     *
+     * @const int
+     */
+    const ENCRYPTION_TLSv1_2 = STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
+
+    /**
+     * Encryption: ANY
+     *
+     * @const int
+     */
+    const ENCRYPTION_ANY     = STREAM_CRYPTO_METHOD_ANY_SERVER;
 
     /**
      * Master connection.


### PR DESCRIPTION
Now this constants are defined in socket implementation:

* Hoa\Socket\Client::ENCRYPTION_TLS_v1_0
* Hoa\Socket\Client::ENCRYPTION_TLS_v1_1
* Hoa\Socket\Client::ENCRYPTION_TLS_v1_2
* Hoa\Socket\Client::ENCRYPTION_ANY
* Hoa\Socket\Server::ENCRYPTION_TLS_v1_0
* Hoa\Socket\Server::ENCRYPTION_TLS_v1_1
* Hoa\Socket\Server::ENCRYPTION_TLS_v1_2
* Hoa\Socket\Server::ENCRYPTION_ANY

Fix #22 