### PR TITLE
Test: Be more flexible about default transports.

### DIFF
--- a/Test/Unit/Transport.php
+++ b/Test/Unit/Transport.php
@@ -57,7 +57,7 @@ class Transport extends Test\Unit\Suite
             ->when($result = SUT::get())
             ->then
                 ->array($result)
-                    ->isEqualTo($standardTransports);
+                    ->strictlyContainsValues($standardTransports);
     }
 
     public function case_get_standards_and_vendors()
@@ -72,7 +72,7 @@ class Transport extends Test\Unit\Suite
             ->when($result = SUT::get())
             ->then
                 ->array($result)
-                    ->isEqualTo(
+                    ->strictlyContainsValues(
                         array_merge(
                             $standardTransports,
                             $vendorTransports


### PR DESCRIPTION
Fix #40.

`SUT::get` can return more values than expected. This is not bad but the test cases will fail. So instead of testing the equality, we test the intersection.